### PR TITLE
switch downloads page config to flex by default

### DIFF
--- a/config.css
+++ b/config.css
@@ -153,8 +153,8 @@
     /* DOWNLOADS PAGE */
     /******************************/
     /* Remove the Dropdown button next to play */
-    --hidedlimage: none !important; /* Set to [ none | flex ] */
-    --hidedlgraph: none !important; /* Set to [ none | flex ] */
+    --hidedlimage: flex !important; /* Set to [ none | flex ] */
+    --hidedlgraph: flex !important; /* Set to [ none | flex ] */
 
 }
 


### PR DESCRIPTION
in some prior update the default setting results in the download statistics being hidden.

this fixes it so that the download stats are visible until a better solution can be implemented.

temporary fix for #14