### PR TITLE
Context menu upgrade and play/install buttons fix

### DIFF
--- a/config.css
+++ b/config.css
@@ -28,6 +28,7 @@
     --librarysidebg: var(--blacker); /* Library sidebar background color */
     --librarybg: var(--darkgrey); /* Library background color */
     --libraryhome: var(--purple); /* Highlight library color */
+    --libraryhomehalf: var(--halfpurple); /* Highlight library color with opacity */
     --downloadspagebg: var(--darkgrey); /* Downloads page background color */
     --downloadspagetop: var(--blacker); /* Downloads page top background color */
     --scrollbar: var(--purple); /* Scrollbar color */
@@ -88,7 +89,7 @@
     --BackgroundColor: transparent; /* Button background color */
     --LibraryButton: flex; /* Hide/Show Library Button, Set to [ none | flex ] */
     --LibrarySearch: flex; /* Hide/Show Library Button, Set to [ none | flex ] */
-    
+
 
     /**********************/
     /* LIBRARY CATEGORIES */
@@ -139,15 +140,15 @@
     /* Remove the Dropdown button next to play */
     --DrowdownPlay: none; /* Set to [ none | flex ] */
 
-    --ButtonPlay: var(--libraryhome); /* Play button color shade 1 */
-    --ButtonPlay2: var(--libraryhome); /* Play button color shade 2 */
-    --ButtonPlayHover: var(--libraryhome); /* Play button hover color shade 1 */
-    --ButtonPlayHover2: var(--libraryhome); /* Play button hover color shade 2 */
-    
-    --ButtonInstall: var(--libraryhome); /* Install button color shade 1 */
-    --ButtonInstall2: var(--libraryhome); /* Install button color shade 2 */
-    --ButtonInstallHover: var(--libraryhome); /* Install button hover color shade 1 */
-    --ButtonInstallHover2: var(--libraryhome); /* Install button hover color shade 2 */
+	--ButtonPlay: var(--libraryhomehalf); /* Play button color shade 1 */
+	--ButtonPlay2: var(--libraryhomehalf); /* Play button color shade 2 */
+	--ButtonPlayHover: var(--libraryhome); /* Play button hover color shade 1 */
+	--ButtonPlayHover2: var(--libraryhome); /* Play button hover color shade 2 */
+
+	--ButtonInstall: var(--libraryhomehalf); /* Install button color shade 1 */
+	--ButtonInstall2: var(--libraryhomehalf); /* Install button color shade 2 */
+	--ButtonInstallHover: var(--libraryhome); /* Install button hover color shade 1 */
+	--ButtonInstallHover2: var(--libraryhome); /* Install button hover color shade 2 */
 
     /******************************/
     /* DOWNLOADS PAGE */

--- a/config.css
+++ b/config.css
@@ -10,6 +10,7 @@
     --lightgrey: #3e3e3f; /* #3e3e3f */
     --white: #ffffff; /* #ffffff */
     --purple: #6624e2; /* #6624e2 */
+    --transpurple: #6624e2b3; /* #6624e2b3 */
     --green: #33ff00; /* #33ff00 */
     --blue: #0066ff; /* #0066ff */
     --pink: #ff00ff; /* #ff00ff */
@@ -28,7 +29,7 @@
     --librarysidebg: var(--blacker); /* Library sidebar background color */
     --librarybg: var(--darkgrey); /* Library background color */
     --libraryhome: var(--purple); /* Highlight library color */
-    --libraryhomehalf: var(--halfpurple); /* Highlight library color with opacity */
+    --libraryhometransp: var(--transpurple); /* Highlight library color with opacity */
     --downloadspagebg: var(--darkgrey); /* Downloads page background color */
     --downloadspagetop: var(--blacker); /* Downloads page top background color */
     --scrollbar: var(--purple); /* Scrollbar color */
@@ -140,13 +141,13 @@
     /* Remove the Dropdown button next to play */
     --DrowdownPlay: none; /* Set to [ none | flex ] */
 
-	--ButtonPlay: var(--libraryhomehalf); /* Play button color shade 1 */
-	--ButtonPlay2: var(--libraryhomehalf); /* Play button color shade 2 */
+	--ButtonPlay: var(--libraryhometransp); /* Play button color shade 1 */
+	--ButtonPlay2: var(--libraryhometransp); /* Play button color shade 2 */
 	--ButtonPlayHover: var(--libraryhome); /* Play button hover color shade 1 */
 	--ButtonPlayHover2: var(--libraryhome); /* Play button hover color shade 2 */
 
-	--ButtonInstall: var(--libraryhomehalf); /* Install button color shade 1 */
-	--ButtonInstall2: var(--libraryhomehalf); /* Install button color shade 2 */
+	--ButtonInstall: var(--libraryhometransp); /* Install button color shade 1 */
+	--ButtonInstall2: var(--libraryhometransp); /* Install button color shade 2 */
 	--ButtonInstallHover: var(--libraryhome); /* Install button hover color shade 1 */
 	--ButtonInstallHover2: var(--libraryhome); /* Install button hover color shade 2 */
 

--- a/css/GamePage.css
+++ b/css/GamePage.css
@@ -31,14 +31,82 @@
   margin-bottom: 0 !important;
 }
 
-[class*="contextmenu_contextMenuItem_"] {
-  border-top: 0 !important;
-  border-bottom: 0 !important;
+/* Context menu itself */
+[class*="contextmenu_contextMenu_"] {
+	background: var(--menudrop) !important;
+	border-radius: var(--Corner1) !important;
+	margin-left: 0 !important;
 }
 
-[class*="contextmenu_contextMenuItem_"]:hover, [class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"] {
-  background: var(--darkgrey) !important;
-  border-radius: var(--Corner0) !important;
+/* Context menu items */
+[class*="contextmenu_contextMenuItem_"] {
+	border-top: 0 !important;
+	border-bottom: 0 !important;
+}
+
+:not([class*="library_ContextMenuAction_"])[class*="contextmenu_contextMenuItem_"]:hover,
+:not([class*="library_ContextMenuAction_"])[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"] {
+	background: var(--darkgrey) !important;
+	border-radius: var(--Corner0) !important;
+	color: var(--white) !important;
+}
+
+[class*="contextmenu_contextMenuItem_"]:first-child:hover,
+[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"]:first-child {
+	border-radius: var(--Corner1) var(--Corner1) var(--Corner0) var(--Corner0) !important;
+}
+
+[class*="contextmenu_contextMenuItem_"]:last-child:hover,
+[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"]:last-child {
+	border-radius: var(--Corner0) var(--Corner0) var(--Corner1) var(--Corner1) !important;
+}
+
+[class*="contextmenu_contextMenuItem_"]:only-child:hover,
+[class*="contextmenu_contextMenuItem_"][class*="contextmenu_active_"]:only-child {
+	border-radius: var(--Corner1) !important;
+}
+
+/* Context menu green (Play etc.) buttons */
+[class*="library_ContextMenuAction_"].Stream,
+[class*="library_ContextMenuAction_"].Connect,
+[class*="library_ContextMenuAction_"].Launch,
+[class*="library_ContextMenuAction_"].PlayMusic,
+[class*="library_ContextMenuAction_"].Play {
+	background: linear-gradient(to right, var(--ButtonPlay) 0%, var(--ButtonPlay2)) 60% !important;
+	border-radius: var(--Corner1) var(--Corner1) var(--Corner0) var(--Corner0) !important;
+}
+[class*="library_ContextMenuAction_"].Stream:hover,
+[class*="library_ContextMenuAction_"].Connect:hover,
+[class*="library_ContextMenuAction_"].Launch:hover,
+[class*="library_ContextMenuAction_"].PlayMusic:hover,
+[class*="library_ContextMenuAction_"].Play:hover {
+	background: linear-gradient(to right, var(--ButtonPlayHover) 0%, var(--ButtonPlayHover2)) 60% !important;
+}
+/* Context menu blue (Download etc.) buttons */
+[class*="library_ContextMenuAction_"].Download,
+[class*="library_ContextMenuAction_"].Update,
+[class*="library_ContextMenuAction_"].PreLoad,
+[class*="library_ContextMenuAction_"].Resume,
+[class*="library_ContextMenuAction_"].Pause,
+[class*="library_ContextMenuAction_"].BorrowApp,
+[class*="library_ContextMenuAction_"].Stop,
+[class*="library_ContextMenuAction_"].Cancel,
+[class*="library_ContextMenuAction_"].Install,
+[class*="library_ContextMenuAction_"].PurchaseApp {
+	background: linear-gradient(to right, var(--ButtonInstall) 0%, var(--ButtonInstall2)) 60% !important;
+	border-radius: var(--Corner1) var(--Corner1) var(--Corner0) var(--Corner0) !important;
+}
+[class*="library_ContextMenuAction_"].Download:hover,
+[class*="library_ContextMenuAction_"].Update:hover,
+[class*="library_ContextMenuAction_"].PreLoad:hover,
+[class*="library_ContextMenuAction_"].Resume:hover,
+[class*="library_ContextMenuAction_"].Pause:hover,
+[class*="library_ContextMenuAction_"].BorrowApp:hover,
+[class*="library_ContextMenuAction_"].Stop:hover,
+[class*="library_ContextMenuAction_"].Cancel:hover,
+[class*="library_ContextMenuAction_"].Install:hover,
+[class*="library_ContextMenuAction_"].PurchaseApp:hover {
+	background: linear-gradient(to right, var(--ButtonInstallHover) 0%, var(--ButtonInstallHover2)) 60% !important;
 }
 
 [class*="appactivityday_Event_"] {
@@ -344,7 +412,7 @@
 }
 
 [class*="appactionbutton_Green_"] > [class*="appactionbutton_ButtonChild_"][class*="appactionbutton_StreamingSelector_"] {
-  background: linear-gradient(to right, var(--ButtonPlayHover) 0%, var(--ButtonPlayHover2)) 100% !important;
+  background: linear-gradient(to right, var(--ButtonPlay) 0%, var(--ButtonPlay2)) 100% !important;
   display: var(--DrowdownPlay) !important;
   border-radius: var(--Corner0) !important;
 }


### PR DESCRIPTION
Before this change context menu was square, basically little to no changes and only background changes
List of changes:

- [x] Fix text on hover being dark and hard to read
- [x] Add rounded corners which are dynamic
- [x] Fix play/install buttons being green/blue
- [x] Fix play/install buttons not changing opacity when hovered (always on max)

Preview:

https://github.com/AikoMidori/steam-library/assets/57235791/9caf5937-6c0b-4c55-9140-fd45650735cb