### PR TITLE
Remove context menu changes from SideBar due to it being in GamePage

### DIFF
--- a/css/GamePage.css
+++ b/css/GamePage.css
@@ -36,6 +36,8 @@
 	background: var(--menudrop) !important;
 	border-radius: var(--Corner1) !important;
 	margin-left: 0 !important;
+	padding: 2px !important;
+	margin-top: 5px !important;
 }
 
 /* Context menu items */

--- a/css/SideBar.css
+++ b/css/SideBar.css
@@ -225,15 +225,6 @@
   background: var(--gamelist) !important;
 }
 
-/* Context Menu Background */
-[class*="contextmenu_contextMenu_"] {
-  background: var(--menudrop) !important;
-  border-radius: var(--Corner0) !important;
-  margin-left: 0 !important;
-  padding: 2px !important;
-  margin-top: 5px !important;
-}
-
 /* Dialog Checkboxes Colors */
 .DialogCheckbox, .DialogCheckbox:hover {
   background: var(--checkbox) !important;


### PR DESCRIPTION
It conflicts with GamePage one so it looks ugly, my bad for not testing it thoroughly
![image](https://github.com/AikoMidori/steam-library/assets/57235791/405fcbb6-8c63-4418-b569-df5d09f0fe93)
